### PR TITLE
Remove DSpace Mig from Query, clarify command name

### DIFF
--- a/dspace-api/src/main/java/org/dspace/util/SolrUpgradePre6xStatistics.java
+++ b/dspace-api/src/main/java/org/dspace/util/SolrUpgradePre6xStatistics.java
@@ -58,7 +58,7 @@ import java.util.*;
  * 
  * @author Terry Brady, Georgetown University Library
  */
-public class SolrUpgradeStatistics6
+public class SolrUpgradePre6xStatistics
 {
         //Command line parameter constants
         private static final String INDEX_NAME_OPTION = "i";
@@ -79,8 +79,15 @@ public class SolrUpgradeStatistics6
         private static final int    FACET_CUTOFF = 10;
         
         private static final String INDEX_DEFAULT = "statistics";
-        private static final String MIGQUERY = "NOT(dspaceMig:*)";
+        private static final String MIGQUERY = "(id:* AND NOT(id:*-*)) OR (scopeId:* AND NOT(scopeId:*-*)) OR (epersonid:* AND NOT(epersonid:*-*))";
 
+        /*
+        private static final String MIGQUERYARR[] = {
+                "id:* AND NOT(id:*-*)",
+                "scopeId:* AND NOT(scopeId:*-*)",
+                "epersonid:* AND NOT(epersonid:*-*)"
+        };
+        */
 
         //Counters to determine the number of items to process
         private int numRec = NUMREC_DEFAULT;
@@ -108,7 +115,7 @@ public class SolrUpgradeStatistics6
         }
         
         //Logger
-        private static final Logger log = Logger.getLogger(SolrUpgradeStatistics6.class);
+        private static final Logger log = Logger.getLogger(SolrUpgradePre6xStatistics.class);
         
         //DSpace Servcies
         private ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
@@ -139,7 +146,7 @@ public class SolrUpgradeStatistics6
          * @throws IOException 
          * @throws SolrServerException 
          */
-        public SolrUpgradeStatistics6(String indexName, int numRec, int batchSize) throws SolrServerException, IOException {
+        public SolrUpgradePre6xStatistics(String indexName, int numRec, int batchSize) throws SolrServerException, IOException {
                 String serverPath = configurationService.getProperty("solr-statistics.server");
                 serverPath = serverPath.replaceAll("statistics$", indexName);
                 System.out.println("Connecting to " + serverPath);
@@ -276,7 +283,7 @@ public class SolrUpgradeStatistics6
         private static void printHelpAndExit(Options options, int exitCode)
         {
                 HelpFormatter myhelp = new HelpFormatter();
-                myhelp.printHelp(SolrUpgradeStatistics6.class.getSimpleName() + "\n", options);
+                myhelp.printHelp(SolrUpgradePre6xStatistics.class.getSimpleName() + "\n", options);
                 System.out.println("\n\nCommand Defaults");
                 System.out.println("\tsolr-upgradeD6-statistics [-i statistics] [-n num_recs_to_process] [-b num_rec_to_update_at_once]");
                 System.out.println("");
@@ -350,7 +357,7 @@ public class SolrUpgradeStatistics6
                 }
                 
                 try {
-                        SolrUpgradeStatistics6 upgradeStats = new SolrUpgradeStatistics6(indexName, numrec, batchSize);
+                    SolrUpgradePre6xStatistics upgradeStats = new SolrUpgradePre6xStatistics(indexName, numrec, batchSize);
                         upgradeStats.run();
                 } catch (SolrServerException e) {
                         log.error("Error querying stats", e);
@@ -440,11 +447,11 @@ public class SolrUpgradeStatistics6
                 runReport();
                 logTime(false);
                 for(int processed = updateRecords(MIGQUERY); (processed != 0) && (numProcessed < numRec);  processed = updateRecords(MIGQUERY)){
-                        printTime(numProcessed, false);
-                        batchUpdateStats();
-                        if (context.getCacheSize() > CACHE_LIMIT) {
-                                refreshContext();
-                        }
+                    printTime(numProcessed, false);
+                    batchUpdateStats();
+                    if (context.getCacheSize() > CACHE_LIMIT) {
+                            refreshContext();
+                    }
                 }                
                 printTime(numProcessed, true);
                 
@@ -485,7 +492,6 @@ public class SolrUpgradeStatistics6
                         for(FIELD col: FIELD.values()) {
                                 mapField(input, col);
                         }
-                        input.addField("dspaceMig", "6.1");
                         
                         docs.add(input);
                         ++numProcessed;

--- a/dspace-api/src/main/java/org/dspace/util/SolrUpgradePre6xStatistics.java
+++ b/dspace-api/src/main/java/org/dspace/util/SolrUpgradePre6xStatistics.java
@@ -79,13 +79,13 @@ public class SolrUpgradePre6xStatistics
         private static final int    FACET_CUTOFF = 10;
         
         private static final String INDEX_DEFAULT = "statistics";
-        private static final String MIGQUERY = "(id:* AND NOT(id:*-*)) OR (scopeId:* AND NOT(scopeId:*-*)) OR (epersonid:* AND NOT(epersonid:*-*))";
+        private static final String MIGQUERY = "(id:* AND -(id:*-*)) OR (scopeId:* AND -(scopeId:*-*)) OR (epersonid:* AND -(epersonid:*-*))";
 
         /*
         private static final String MIGQUERYARR[] = {
-                "id:* AND NOT(id:*-*)",
-                "scopeId:* AND NOT(scopeId:*-*)",
-                "epersonid:* AND NOT(epersonid:*-*)"
+                "id:* AND -(id:*-*)",
+                "scopeId:* AND -(scopeId:*-*)",
+                "epersonid:* AND -(epersonid:*-*)"
         };
         */
 

--- a/dspace/config/launcher.xml
+++ b/dspace/config/launcher.xml
@@ -243,10 +243,10 @@
         </step>
     </command>
     <command>
-        <name>solr-upgradeD6-statistics</name>
+        <name>solr-upgrade-pre6x-statistics</name>
         <description>Upgrade statistics (integer to UUID) to DSpace 6</description>
         <step passuserargs="true">
-            <class>org.dspace.util.SolrUpgradeStatistics6</class>
+            <class>org.dspace.util.SolrUpgradePre6xStatistics</class>
         </step>
     </command>
     <command>


### PR DESCRIPTION
Note, in a test environment where not all records will migrated, this approach can get into a loop where it will re-process records that cannot be migrated.  

When a valid database mapping cannot be made for a record, we need a way to mark that record as un-migratable.